### PR TITLE
Fixes for 667b5e6

### DIFF
--- a/kernel/include/lunaros/video/tty.h
+++ b/kernel/include/lunaros/video/tty.h
@@ -14,7 +14,11 @@
 #define TTY_MAX_HEIGHT (24)
 #endif /* TTY_MAX_HEIGHT */
 
-void init_tty(void);
-void clrscr(void);
+/* White foreground, black background */
+#ifndef DEFAULT_COLOR
+#define DEFAULT_COLOR (0x0F)
+#endif /* DEFAULT_COLOR */
+
+void cls(void);
 
 #endif /* _TTY_H */

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -1,17 +1,15 @@
-#include <std/stdint.h>
 #include <multiboot/multiboot2.h>
+#include <std/stdint.h>
 
 #include <lunaros/printf.h>
 #include <lunaros/video/tty.h>
 
 void main(uint32_t magic, uint32_t addr) {
    ((void)addr);
-   init_tty();
+   cls();
    if (magic != MULTIBOOT2_BOOTLOADER_MAGIC) {
-      printf("Invalid magic number");
+      puts("Invalid magic number");
       return;
    }
-   clrscr();
    puts("LunarOS Kernel\n");
-   printf("Print several numbers... %x %d %d", 16*16+10, -3, 2*2 + 2 + 1);
 }


### PR DESCRIPTION
- Enforced clang-format style
- Changed some function names
- Removed tty_init()
- Made '\r' to be treated as a new line